### PR TITLE
FIX squid scope for inner router

### DIFF
--- a/test/squid/routing_test.exs
+++ b/test/squid/routing_test.exs
@@ -19,7 +19,7 @@ defmodule SquidWeb.RoutingTest do
   Application.put_env(:tentacle_c, :squid, router: SquidWeb.RoutingTest.RouterC)
 
   defmodule RouterA do
-    use SquidWeb.Router
+    use SquidWeb.Router, otp_app: :tentacle_a
     alias CustomController, as: CustomControllerAliased
 
     squid_pipeline :tentacle_a_browser do
@@ -46,7 +46,7 @@ defmodule SquidWeb.RoutingTest do
   end
 
   defmodule RouterB do
-    use SquidWeb.Router
+    use SquidWeb.Router, otp_app: :tentacle_b
 
     squid_pipeline :tentacle_b_browser do
       plug(:add_header)
@@ -63,7 +63,7 @@ defmodule SquidWeb.RoutingTest do
   end
 
   defmodule RouterC do
-    use SquidWeb.Router
+    use SquidWeb.Router, otp_app: :tentacle_c
 
     squid_scope "/tentacle-c" do
       pipe_through(:tentacle_c_add_header)


### PR DESCRIPTION
The inner router didn't replace `{{tentacle_name}}` the only way is to use a `otp_app` config system.
In that way we will be able to add a `tentacle_name` option in config later